### PR TITLE
Added passPercentage property

### DIFF
--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -100,6 +100,7 @@ H5P.MultiChoice = function(options, contentId, contentData) {
       shouldNotCheck: "Should not have been checked",
       noInput: 'Input is required before viewing the solution'
     },
+    passPercentage: 100,
     behaviour: {
       enableRetry: true,
       enableSolutionsButton: true,
@@ -752,7 +753,7 @@ H5P.MultiChoice = function(options, contentId, contentData) {
       score = params.weight;
     }
     if (params.behaviour.singlePoint) {
-      score = (score === calculateMaxScore() ? params.weight : 0);
+      score = (100 * score / calculateMaxScore()) >= params.passPercentage ? params.weight : 0;
     }
   };
 
@@ -840,7 +841,8 @@ H5P.MultiChoice = function(options, contentId, contentData) {
    */
   var addResponseToXAPI = function(xAPIEvent) {
     var maxScore = self.getMaxScore();
-    var success = score == maxScore ? true : false;
+    var success = (100 * score / maxScore) >= params.passPercentage;
+
     xAPIEvent.setScoredResult(score, maxScore, self, true, success);
     if (params.userAnswers === undefined) {
       calcScore();

--- a/semantics.json
+++ b/semantics.json
@@ -243,6 +243,16 @@
     ]
   },
   {
+    "name": "passPercentage",
+    "type": "number",
+    "label": "Pass percentage",
+    "description": "Percentage of Total score required for passing the quiz.",
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "default": 100
+  },
+  {
     "name": "behaviour",
     "type": "group",
     "label": "Behavioural settings.",


### PR DESCRIPTION
Added "passPercentage" property. This allows flexible customizing the question with the singlePoint option.
E.g. when one of two correct answers enough to mark the question as a correct. In this case just need to set passPercentage 50.