### PR TITLE
Put full answer text in xapi statements

### DIFF
--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -960,8 +960,12 @@ H5P.MultiChoice = function (options, contentId, contentData) {
       if (response !== '') {
         response += '[,]';
       }
-      response += idMap === undefined ? params.userAnswers[i] : idMap[params.userAnswers[i]];
-    }
+      if (idMap === undefined) {
+        response += $('<div>' + params.answers[params.userAnswers[i]].text + '</div>').text();
+      }
+      else {
+        response += $('<div>' + params.answers[params.userAnswers[i]].text + '</div>').text();
+      }
     xAPIEvent.data.statement.result.response = response;
   };
 


### PR DESCRIPTION
Adding this if/else has the script push the full text for the selected answer to xAPI statements rather than having the statement reference a number in the array of answers. This makes xAPI statements more readable and helps instructional technologists prepare visualizations and exports from learning record stores for instructors.