### PR TITLE
Please fix es and es-mx translations

### DIFF
--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -8,7 +8,7 @@
           "description": "Medios opcionales para mostrar sobre la pregunta."
         },
         {
-          "label": "Desactivar zoom de imagen para imagen de pregunta"
+          "label": "Desactivar zoom de imagen"
         }
       ]
     },

--- a/language/es.json
+++ b/language/es.json
@@ -8,7 +8,7 @@
           "description": "Medios opcionales para mostrar sobre la pregunta."
         },
         {
-          "label": "Desactivar zoom de imagen para imagen de pregunta"
+          "label": "Desactivar zoom de imagen"
         }
       ]
     },


### PR DESCRIPTION
The previous translation had extra words, when it shouldn't.
Thanks in advance.