### PR TITLE
Removed aria-hidden, accessibilty fix

### DIFF
--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -159,7 +159,7 @@ H5P.MultiChoice = function(options, contentId, contentData) {
     $feedbackDialog = $('' +
     '<div class="h5p-feedback-dialog">' +
       '<div class="h5p-feedback-inner">' +
-        '<div class="h5p-feedback-text" aria-hidden="true">' + feedback + '</div>' +
+        '<div class="h5p-feedback-text">' + feedback + '</div>' +
       '</div>' +
     '</div>');
 


### PR DESCRIPTION
The aria-hidden="true" attribute was preventing screen readers from reading the content of the feedback area with a multiple choice question. Removed it, as it seems to serve no purpose.