### PR TITLE
HFP-3645 Fix calls to showSolutions or resetTask

### DIFF
--- a/js/multichoice.js
+++ b/js/multichoice.js
@@ -524,6 +524,10 @@ H5P.MultiChoice = function (options, contentId, contentData) {
    * Shows the solution for the task and hides all buttons.
    */
   this.showSolutions = function () {
+    if (!$myDom) {
+      return; // Exercise was not yet attached
+    }
+
     removeFeedbackDialog();
     self.showCheckSolution();
     self.showAllSolutions();
@@ -572,6 +576,10 @@ H5P.MultiChoice = function (options, contentId, contentData) {
    * @private
    */
   this.resetTask = function () {
+    if (!$myDom) {
+      return; // Exercise was not yet attached
+    }
+
     self.answered = false;
     self.hideSolutions();
     params.userAnswers = [];


### PR DESCRIPTION
Currently, when Multiple Choice questions are subcontent and the parent content does not attach Multiple Choice content when instantiating, but dynamically as needed like Interactive Book, calls to the [Question Type contract](https://h5p.org/documentation/developers/contracts) functions `showSolutions` and `resetTask` will crash Multiple Choice. That's because Multiple Choice assumes that it's DOM elements have already been attached to the page, but doesn't check.

When merged in, a guard will be added to the `showSolutions` function and the `resetTask` function to prevent crashes.