### PR TITLE
Update French translations (fr.json)

### DIFF
--- a/language/fr.json
+++ b/language/fr.json
@@ -98,9 +98,9 @@
           "default": "Afficher les indices"
         },
         {
-          "label": "Textual representation of the score bar for those using a readspeaker",
-          "description": "Available variables are :num and :total",
-          "default": "You got :num out of :total points"
+          "label": "Représentation textuelle de la barre de score pour les utilisateurs de lecteur d'écran",
+          "description": "Les variables disponibles sont :num et :total",
+          "default": "Vous avez obtenu :num points sur :total"
         },
         {
           "label": "Indice disponible (ne s'affiche pas)",


### PR DESCRIPTION
Updates/improves French translations in `language/fr.json`.

Changes include:
- Translated score bar accessibility label and description
- Translated default text for screen reader score announcement